### PR TITLE
fix: Updated prisma/reflector package to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prepare": "ts-patch install -s"
   },
   "dependencies": {
-    "@prisma-spectrum/reflector": "^0.6.0",
+    "@prisma-spectrum/reflector": "^0.6.2",
     "lodash": "^4.17.21",
     "tslib": "^2.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1001,10 +1001,10 @@
   resolved "https://registry.yarnpkg.com/@prisma-labs/prettier-config/-/prettier-config-0.1.0.tgz#ef6cb5f89487974ca997516e9b39d5ccbefeeaad"
   integrity sha512-P0h2y+gnIxFP2HdsTYSYHWmabGBlxyVjnUepsrRe8gAF36mxOonGsbsQmKt/Q9H9CMjrSkFoDe5F5HLi2iW5/Q==
 
-"@prisma-spectrum/reflector@^0.6.0":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@prisma-spectrum/reflector/-/reflector-0.6.1.tgz#8d1fdd8db1dbcce51797fb98cf988172181e4136"
-  integrity sha512-+TvjJyW8xaFjj3pHYw+EL0rKkFbTYJhmhA4V2r5RhHvylwOVGwLrQK6YWGRkNMZmvO/SXMJPZ99ajMKbWqRoEw==
+"@prisma-spectrum/reflector@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@prisma-spectrum/reflector/-/reflector-0.6.2.tgz#1544fa2edddf44beae3bfd3fba6479d3f372cbf7"
+  integrity sha512-Y5KIvMxt08ZQObedfIdLLI6T53OnbdSEFzgeJewtSbWB6lUpDYZ+TJTcEzuNtJ9Ck8Qa0VWPxzTqFFR6JtuUZA==
   dependencies:
     "@opentelemetry/api" "^1.0.4"
     remeda "^0.0.32"


### PR DESCRIPTION
This [pr](https://github.com/prisma/reflector/pull/12) on fixes the Safari compatibility issue with the `datasourceBlockPattern` regex.

This PR just updates the version of the [library](https://github.com/prisma/reflector) to contain this change.