### PR TITLE
fix: tests for blog template

### DIFF
--- a/tests/__snapshots__/templates-instances.spec.ts.snap
+++ b/tests/__snapshots__/templates-instances.spec.ts.snap
@@ -616,7 +616,7 @@ const handler: NextApiHandler = async (req, res) => {
     res.status(201).json(createdUsers)
   } catch (error) {
     console.error(error)
-    return res.status(500).end()
+    res.status(500).end()
   }
 }
 
@@ -1460,7 +1460,7 @@ const handler: NextApiHandler = async (req, res) => {
     res.status(201).json(createdUsers)
   } catch (error) {
     console.error(error)
-    return res.status(500).end()
+    res.status(500).end()
   }
 }
 
@@ -2268,7 +2268,7 @@ const handler: NextApiHandler = async (req, res) => {
     res.status(201).json(createdUsers)
   } catch (error) {
     console.error(error)
-    return res.status(500).end()
+    res.status(500).end()
   }
 }
 
@@ -3110,7 +3110,7 @@ const handler: NextApiHandler = async (req, res) => {
     res.status(201).json(createdUsers)
   } catch (error) {
     console.error(error)
-    return res.status(500).end()
+    res.status(500).end()
   }
 }
 
@@ -3954,7 +3954,7 @@ const handler: NextApiHandler = async (req, res) => {
     res.status(201).json(createdUsers)
   } catch (error) {
     console.error(error)
-    return res.status(500).end()
+    res.status(500).end()
   }
 }
 
@@ -4761,7 +4761,7 @@ const handler: NextApiHandler = async (req, res) => {
     res.status(201).json(createdUsers)
   } catch (error) {
     console.error(error)
-    return res.status(500).end()
+    res.status(500).end()
   }
 }
 

--- a/tests/__snapshots__/templates-static-data.spec.ts.snap
+++ b/tests/__snapshots__/templates-static-data.spec.ts.snap
@@ -227,7 +227,7 @@ const handler: NextApiHandler = async (req, res) => {
     res.status(201).json(createdUsers)
   } catch (error) {
     console.error(error)
-    return res.status(500).end()
+    res.status(500).end()
   }
 }
 


### PR DESCRIPTION
Related to https://linear.app/prisma-company/issue/CP-2176/fix-nextjs-template-failure-to-deploy-on-vercel