### PR TITLE
fix: update peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "typescript-transform-paths": "3.3.1"
   },
   "peerDependencies": {
-    "@prisma/client": "^3.5",
-    "@prisma/sdk": "^3.5"
+    "@prisma/client": "*",
+    "@prisma/internals": "*"
   }
 }


### PR DESCRIPTION
Renamed `@prisma/sdk` -> `@prisma/internals` in peer dependencies